### PR TITLE
Don't run CI on `main` branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,6 @@ concurrency:
 on:
   pull_request:
   merge_group:
-  push:
-    branches: [main]
 
 jobs:
   ci:


### PR DESCRIPTION
How merge queues are configured give us the same safety net so this is redundant.