### PR TITLE
`CorrelationId` throws `InvalidUuidString` on bad input

### DIFF
--- a/src/CorrelationId.php
+++ b/src/CorrelationId.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Lendable\Message;
 
+use Ramsey\Uuid\Exception\InvalidArgumentException;
+use Ramsey\Uuid\Exception\InvalidUuidStringException;
 use Ramsey\Uuid\Uuid as RamseyUuid;
 use Ramsey\Uuid\UuidInterface;
 
@@ -25,12 +27,20 @@ final class CorrelationId implements Uuid
 
     public static function fromString(string $id): static
     {
-        return new self(RamseyUuid::fromString($id));
+        try {
+            return new self(RamseyUuid::fromString($id));
+        } catch (InvalidUuidStringException $exception) {
+            throw InvalidUuidString::hexString($id, $exception);
+        }
     }
 
     public static function fromBinaryString(string $id): static
     {
-        return new self(RamseyUuid::fromBytes($id));
+        try {
+            return new self(RamseyUuid::fromBytes($id));
+        } catch (InvalidArgumentException $exception) {
+            throw InvalidUuidString::binaryString($id, $exception);
+        }
     }
 
     public function toString(): string

--- a/tests/unit/CorrelationIdTest.php
+++ b/tests/unit/CorrelationIdTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Lendable\Message;
 
 use Lendable\Message\CorrelationId;
+use Lendable\Message\InvalidUuidString;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -40,6 +41,22 @@ final class CorrelationIdTest extends TestCase
 
         self::assertSame(UuidGenerator::stringFromBinaryString($string), $instance->toString());
         self::assertSame($string, $instance->toBinary());
+    }
+
+    #[Test]
+    public function it_throws_when_constructed_from_invalid_hex_string(): void
+    {
+        $this->expectExceptionObject(InvalidUuidString::hexString('foo'));
+
+        CorrelationId::fromString('foo');
+    }
+
+    #[Test]
+    public function it_throws_when_constructed_from_invalid_binary_string(): void
+    {
+        $this->expectExceptionObject(InvalidUuidString::binaryString('foo'));
+
+        CorrelationId::fromBinaryString('foo');
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #39 