### PR TITLE
chore(phpstan): disable `treatPhpDocTypesAsCertain`

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -37,3 +37,4 @@ parameters:
   tmpDir: tmp/phpstan
 
   checkMissingIterableValueType: true
+  treatPhpDocTypesAsCertain: false

--- a/tests/unit/BinaryStringUuidConverterTest.php
+++ b/tests/unit/BinaryStringUuidConverterTest.php
@@ -24,7 +24,7 @@ final class BinaryStringUuidConverterTest extends TestCase
         $converter = new BinaryStringUuidConverter();
         $id = $converter->convert($binaryString, MessageId::class);
 
-        self::assertInstanceOf(MessageId::class, $id); // @phpstan-ignore-line we want to not trust phpdoc generics here.
+        self::assertInstanceOf(MessageId::class, $id);
         self::assertSame('70d99e3b-af6e-4174-8982-e32890cffb02', $id->toString());
     }
 }

--- a/tests/unit/StringUuidConverterTest.php
+++ b/tests/unit/StringUuidConverterTest.php
@@ -21,7 +21,7 @@ final class StringUuidConverterTest extends TestCase
         $converter = new StringUuidConverter();
         $id = $converter->convert('ddb802d4-3bfb-44c0-a257-eb6178791259', MessageId::class);
 
-        self::assertInstanceOf(MessageId::class, $id); // @phpstan-ignore-line we want to not trust phpdoc generics here.
+        self::assertInstanceOf(MessageId::class, $id);
         self::assertSame('ddb802d4-3bfb-44c0-a257-eb6178791259', $id->toString());
     }
 }


### PR DESCRIPTION
As a library we cannot control that downstream will always also use sufficient static analysis to not provide invalid arguments. 