### PR TITLE
chore(DEVOPS-8186): update renovate config to use public renovate-config-public

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-      "local>Lendable/renovate-config-public",
+      "local>Lendable/renovate-config-public-public",
       ":semanticCommits"
     ]
 }


### PR DESCRIPTION
# [DEVOPS-8186]
# Update Renovate Configuration
## Changes

Update the renovate configuration to use the new publicly available `renovate-config-public` repository instead of the internal `renovate-config`.

## Why

This change migrates our public repositories to use the new public renovate configuration repository, ensuring proper separation between internal and public repository configurations.

Once this has been done for all public repositories, `renovate-config` repository can be made internal and our more sensitive configuration can be added here.


[DEVOPS-8186]: https://lendable-uk.atlassian.net/browse/DEVOPS-8186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ