### PR TITLE
feat: introduce `MessageContext` to simplify passing message identifiers

### DIFF
--- a/src/ContextAwareMessageTrait.php
+++ b/src/ContextAwareMessageTrait.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lendable\Message;
+
+trait ContextAwareMessageTrait
+{
+    public readonly MessageContext $context;
+
+    public function id(): MessageId
+    {
+        return $this->context->id;
+    }
+
+    public function causationId(): MessageId
+    {
+        return $this->context->causationId;
+    }
+
+    public function correlationId(): CorrelationId
+    {
+        return $this->context->correlationId;
+    }
+}

--- a/src/MessageContext.php
+++ b/src/MessageContext.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Lendable\Message;
+
+final readonly class MessageContext
+{
+    public function __construct(
+        public MessageId $id,
+        public MessageId $causationId,
+        public CorrelationId $correlationId,
+    ) {}
+
+    public static function generate(): self
+    {
+        $id = MessageId::generate();
+
+        return new self($id, $id, CorrelationId::generate());
+    }
+
+    public static function generateChild(MessageId $causationId, CorrelationId $correlationId): self
+    {
+        return new self(MessageId::generate(), $causationId, $correlationId);
+    }
+
+    public function child(): self
+    {
+        return self::generateChild($this->id, $this->correlationId);
+    }
+}

--- a/tests/unit/ContextAwareMessageTraitTest.php
+++ b/tests/unit/ContextAwareMessageTraitTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Lendable\Message;
+
+use Lendable\Message\ContextAwareMessageTrait;
+use Lendable\Message\Message;
+use Lendable\Message\MessageContext;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(ContextAwareMessageTrait::class)]
+#[DisableReturnValueGenerationForTestDoubles]
+final class ContextAwareMessageTraitTest extends TestCase
+{
+    #[Test]
+    public function exposes_context_identifiers(): void
+    {
+        $context = MessageContext::generate();
+
+        $message = $this->createMessageUsingTrait($context);
+
+        self::assertTrue($context->id->equals($message->id()));
+        self::assertTrue($context->causationId->equals($message->causationId()));
+        self::assertTrue($context->correlationId->equals($message->correlationId()));
+    }
+
+    private function createMessageUsingTrait(
+        MessageContext $context,
+    ): Message {
+        return new class ($context) implements Message {
+            use ContextAwareMessageTrait;
+
+            public function __construct(
+                public readonly MessageContext $context,
+            ) {}
+        };
+    }
+}

--- a/tests/unit/MessageContextTest.php
+++ b/tests/unit/MessageContextTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Lendable\Message;
+
+use Lendable\Message\CorrelationId;
+use Lendable\Message\MessageContext;
+use Lendable\Message\MessageId;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DisableReturnValueGenerationForTestDoubles;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(MessageContext::class)]
+#[DisableReturnValueGenerationForTestDoubles]
+final class MessageContextTest extends TestCase
+{
+    #[Test]
+    public function generatable(): void
+    {
+        $context = MessageContext::generate();
+
+        self::assertTrue($context->id->equals($context->causationId));
+
+        $anotherContext = MessageContext::generate();
+
+        self::assertFalse($context->id->equals($anotherContext->id));
+        self::assertFalse($context->correlationId->equals($anotherContext->correlationId));
+    }
+
+    #[Test]
+    public function generatable_as_child(): void
+    {
+        $causationId = MessageId::generate();
+        $correlationId = CorrelationId::generate();
+
+        $context = MessageContext::generateChild($causationId, $correlationId);
+
+        self::assertFalse($context->id->equals($causationId));
+        self::assertTrue($context->causationId->equals($causationId));
+        self::assertTrue($context->correlationId->equals($correlationId));
+    }
+
+    #[Test]
+    public function creates_child_context(): void
+    {
+        $parentContext = MessageContext::generate();
+        $childContext = $parentContext->child();
+
+        self::assertFalse($childContext->id->equals($parentContext->id));
+        self::assertTrue($childContext->causationId->equals($parentContext->id));
+        self::assertTrue($childContext->correlationId->equals($parentContext->correlationId));
+    }
+}


### PR DESCRIPTION
This PR introduces `MessageContext` that allows to bundle the three message identifiers (`id`, `causationId`, `correlationId`) into a single value object, reducing method signature complexity from 3 parameters to 1.

The new `ContextAwareMessageTrait` demonstrates this pattern, and creating child messages is simplified to `$context->child()` instead of manually propagating identifiers.

This is a non-breaking addition - existing `MessageTrait` usage remains unchanged.