### PR TITLE
chore(deps): update dependency composer/composer to v2.9.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         run: apk add --no-cache bash git su-exec
 
       - name: "Install composer"
-        run: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version=2.9.7
+        run: curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer --version=2.9.8
 
       - name: "Checkout"
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6


### PR DESCRIPTION
## Summary

- Bumps the Composer binary installed in CI from `2.9.7` to `2.9.8`.

## Test plan

- [ ] CI passes — Composer installs and dependency install/validate steps succeed against the new version.